### PR TITLE
fix: pac pcf commands are cross-platform, not Windows-only

### DIFF
--- a/skills/pac-pcf/SKILL.md
+++ b/skills/pac-pcf/SKILL.md
@@ -6,6 +6,8 @@ The user wants to work with PCF components using the Power Platform CLI (`pac`).
 
 **Argument provided:** $ARGUMENTS
 
+> **Cross-platform note:** The PAC CLI (`pac pcf init`, `pac pcf push`, `pac solution`) runs on **macOS, Linux, and Windows** via .NET. Do NOT tell the user these commands are Windows-only — they work on Mac. The only Windows-specific tool is `msbuild`; use `dotnet build` instead on Mac/Linux.
+
 ## Prerequisites
 
 Before running any commands, verify `pac` is installed:


### PR DESCRIPTION
## Summary

- Adds an explicit note to `pac-pcf/SKILL.md` clarifying that `pac pcf init`, `pac pcf push`, and other PAC CLI commands run on **macOS, Linux, and Windows** via .NET
- Prevents Claude from incorrectly blocking Mac users with a "Windows-only" warning (caused by stale training data)
- Only `msbuild` is Windows-specific — the skill already documents `dotnet build` as the Mac/Linux alternative

## Test plan
- [ ] On macOS, ask Claude to "create a new PCF component" — it should proceed with `pac pcf init`, not block with a Windows-only error

🤖 Generated with [Claude Code](https://claude.com/claude-code)