### PR TITLE
feat: bulk deletion job CRUD & monitoring tools

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -428,6 +428,81 @@ const tools: Tool[] = [
     },
   },
 
+  // ──────────────────────── BULK DELETE OPERATIONS ──────────────────────────
+  {
+    name: "create_bulk_delete_job",
+    description: "Create a bulk deletion job to asynchronously delete records matching a query. Returns a JobId (asyncoperationid) that can be monitored with get_bulk_delete_job.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        job_name: { type: "string", description: "Display name for the bulk delete job" },
+        entity: { type: "string", description: "Entity logical name to delete from (e.g. 'knowledgearticle', 'task')" },
+        filter_conditions: {
+          type: "array",
+          description: "Optional QueryExpression conditions. If omitted, ALL records of the entity are targeted.",
+          items: {
+            type: "object",
+            properties: {
+              attribute: { type: "string", description: "Attribute logical name (e.g. 'statuscode')" },
+              operator: { type: "string", description: "Condition operator: Equal, NotEqual, NotNull, Null, Like, In, GreaterThan, LessThan, OlderThanXDays, etc." },
+              values: { type: "array", items: { type: "string" }, description: "Values for the condition (omit for Null/NotNull)" },
+            },
+            required: ["attribute", "operator"],
+          },
+        },
+        start_datetime: { type: "string", description: "ISO 8601 start time (default: now)" },
+        recurrence_pattern: { type: "string", description: "Recurrence rule string (empty for one-time run)" },
+        send_email_notification: { type: "boolean", description: "Send email on completion (default false)" },
+      },
+      required: ["job_name", "entity"],
+    },
+  },
+  {
+    name: "list_bulk_delete_jobs",
+    description: "List bulk deletion jobs. Filter by status to monitor running or completed jobs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        status: { type: "string", description: "Filter by status: waiting, running, completed, failed, cancelled. Omit for all." },
+        top: { type: "number", description: "Max results (default 20)" },
+      },
+    },
+  },
+  {
+    name: "get_bulk_delete_job",
+    description: "Get the status and progress of a specific bulk deletion job by its JobId (asyncoperationid).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        job_id: { type: "string", description: "The asyncoperationid (JobId) returned by create_bulk_delete_job" },
+      },
+      required: ["job_id"],
+    },
+  },
+  {
+    name: "cancel_bulk_delete_job",
+    description: "Cancel a bulk deletion job that is waiting or running. This deletes the async operation record.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        job_id: { type: "string", description: "The asyncoperationid (JobId) to cancel" },
+      },
+      required: ["job_id"],
+    },
+  },
+  {
+    name: "get_bulk_delete_failures",
+    description: "Get the list of records that failed to be deleted in a bulk delete job.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        job_id: { type: "string", description: "The asyncoperationid (JobId)" },
+        top: { type: "number", description: "Max failure records to return (default 50)" },
+      },
+      required: ["job_id"],
+    },
+  },
+
   // ───────────────────────────── SECURITY & USERS ────────────────────────────
   {
     name: "get_current_user",
@@ -1420,6 +1495,83 @@ async function handleAssociateRecords(args: { entity: string; id: string; relati
   requireEnv();
   return d365(`${args.entity}(${args.id})/${args.relationship}/$ref`, "POST",
     { "@odata.id": `${getBaseUrl()}/${args.related_entity}(${args.related_id})` });
+}
+
+// ──────────────────────── Bulk Delete Operations ──────────────────────────
+
+async function handleCreateBulkDeleteJob(args: {
+  job_name: string;
+  entity: string;
+  filter_conditions?: Array<{ attribute: string; operator: string; values?: string[] }>;
+  start_datetime?: string;
+  recurrence_pattern?: string;
+  send_email_notification?: boolean;
+}) {
+  requireEnv();
+  const query: Record<string, unknown> = {
+    "@odata.type": "Microsoft.Dynamics.CRM.QueryExpression",
+    EntityName: args.entity,
+    ColumnSet: { "@odata.type": "Microsoft.Dynamics.CRM.ColumnSet", AllColumns: false, Columns: [`${args.entity}id`] },
+    Distinct: false,
+    NoLock: false,
+  };
+  if (args.filter_conditions && args.filter_conditions.length > 0) {
+    query.Criteria = {
+      "@odata.type": "Microsoft.Dynamics.CRM.FilterExpression",
+      FilterOperator: "And",
+      Conditions: args.filter_conditions.map((c) => ({
+        "@odata.type": "Microsoft.Dynamics.CRM.ConditionExpression",
+        AttributeName: c.attribute,
+        Operator: c.operator,
+        Values: c.values ?? [],
+      })),
+    };
+  }
+  return d365("BulkDelete", "POST", {
+    QuerySet: [query],
+    JobName: args.job_name,
+    SendEmailNotification: args.send_email_notification ?? false,
+    ToRecipients: [],
+    CCRecipients: [],
+    RecurrencePattern: args.recurrence_pattern ?? "",
+    StartDateTime: args.start_datetime ?? new Date().toISOString(),
+  });
+}
+
+async function handleListBulkDeleteJobs(args: { status?: string; top?: number }) {
+  requireEnv();
+  const statusFilters: Record<string, string> = {
+    waiting: "statuscode eq 10",
+    running: "statuscode eq 20",
+    completed: "statecode eq 3 and statuscode eq 30",
+    failed: "statecode eq 3 and statuscode eq 33",
+    cancelled: "statecode eq 3 and statuscode eq 32",
+  };
+  const top = Math.min(args.top ?? 20, 100);
+  const statusClause = args.status && statusFilters[args.status] ? ` and (${statusFilters[args.status]})` : "";
+  return d365(
+    `asyncoperations?$filter=operationtype eq 13${statusClause}&$select=asyncoperationid,name,statecode,statuscode,createdon,completedon,message&$orderby=createdon desc&$top=${top}`
+  );
+}
+
+async function handleGetBulkDeleteJob(args: { job_id: string }) {
+  requireEnv();
+  return d365(
+    `asyncoperations(${args.job_id})?$select=asyncoperationid,name,statecode,statuscode,createdon,completedon,message,operationtype`
+  );
+}
+
+async function handleCancelBulkDeleteJob(args: { job_id: string }) {
+  requireEnv();
+  return d365(`asyncoperations(${args.job_id})`, "DELETE");
+}
+
+async function handleGetBulkDeleteFailures(args: { job_id: string; top?: number }) {
+  requireEnv();
+  const top = Math.min(args.top ?? 50, 500);
+  return d365(
+    `bulkdeletefailures?$filter=asyncoperationid/asyncoperationid eq ${args.job_id}&$select=bulkdeletefailureid,objectid,orderfailure,errordescription&$top=${top}`
+  );
 }
 
 // ───────────────────────────── Security & Users ──────────────────────────────
@@ -2517,6 +2669,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "execute_fetchxml": result = await handleExecuteFetchXml(args as any); break;
       case "execute_action": result = await handleExecuteAction(args as any); break;
       case "associate_records": result = await handleAssociateRecords(args as any); break;
+      // Bulk Delete
+      case "create_bulk_delete_job": result = await handleCreateBulkDeleteJob(args as any); break;
+      case "list_bulk_delete_jobs": result = await handleListBulkDeleteJobs(args as any); break;
+      case "get_bulk_delete_job": result = await handleGetBulkDeleteJob(args as any); break;
+      case "cancel_bulk_delete_job": result = await handleCancelBulkDeleteJob(args as any); break;
+      case "get_bulk_delete_failures": result = await handleGetBulkDeleteFailures(args as any); break;
       // Security & Users
       case "get_current_user": result = await handleGetCurrentUser(); break;
       case "find_users": result = await handleFindUsers(args as any); break;

--- a/skills/bulk-delete/SKILL.md
+++ b/skills/bulk-delete/SKILL.md
@@ -1,0 +1,95 @@
+---
+description: Create, monitor, and manage bulk deletion jobs in Dynamics 365. Use when asked "bulk delete", "delete all records of type X", "create a bulk delete job", "check bulk delete status", "cancel bulk delete", "why did bulk delete fail".
+allowed-tools: mcp__dynamics365__list_environments, mcp__dynamics365__select_environment, mcp__dynamics365__create_bulk_delete_job, mcp__dynamics365__list_bulk_delete_jobs, mcp__dynamics365__get_bulk_delete_job, mcp__dynamics365__cancel_bulk_delete_job, mcp__dynamics365__get_bulk_delete_failures, mcp__dynamics365__list_entities, mcp__dynamics365__get_entity_attributes
+---
+
+The user wants to create or manage bulk deletion jobs in Dynamics 365.
+
+**Argument provided:** $ARGUMENTS
+
+## Process
+
+### "Delete all records of entity X" / "Create a bulk delete job"
+
+1. **Select environment** — call `list_environments`, ask the user, call `select_environment`.
+
+2. **Confirm scope** — ask the user to confirm the target entity and any filter conditions before creating the job. Bulk deletion is irreversible.
+
+3. **Resolve the entity logical name** — if the user provides a display name (e.g. "Knowledge Article"), use `list_entities` to find the logical name (e.g. `knowledgearticle`).
+
+4. **Build filter conditions (optional)** — if the user wants to delete a subset of records, map their criteria to QueryExpression conditions:
+   - Each condition has: `attribute` (logical name), `operator`, and optionally `values`
+   - Common operators: `Equal`, `NotEqual`, `Null`, `NotNull`, `Like`, `In`, `GreaterThan`, `LessThan`, `OlderThanXDays`
+   - Example — delete only inactive records: `{ attribute: "statecode", operator: "Equal", values: ["1"] }`
+   - If no filter is provided, ALL records of the entity will be deleted.
+
+5. **Create the job** — call `create_bulk_delete_job`:
+   ```
+   job_name: descriptive name (e.g. "Delete all Knowledge Articles – 2026-05-04")
+   entity: logical name (e.g. "knowledgearticle")
+   filter_conditions: [...] or omit for all records
+   ```
+   Returns a `JobId` (asyncoperationid) — save this for monitoring.
+
+6. **Confirm to the user** — report the `JobId` and explain they can monitor it with `get_bulk_delete_job`.
+
+---
+
+### "Check status of bulk delete job" / "Is the bulk delete done?"
+
+Call `get_bulk_delete_job` with the `job_id`.
+
+**Status interpretation:**
+
+| statecode | statuscode | Meaning |
+|-----------|------------|---------|
+| 0 | 0 | Waiting for resources |
+| 1 | 10 | Waiting |
+| 2 | 20 | In progress |
+| 2 | 21 | Pausing |
+| 2 | 22 | Canceling |
+| 3 | 30 | Succeeded |
+| 3 | 32 | Cancelled |
+| 3 | 33 | Failed |
+
+- If **in progress** — report current state; tell user to check again shortly.
+- If **succeeded** — report completion time; offer to check for any failures with `get_bulk_delete_failures`.
+- If **failed** — call `get_bulk_delete_failures` to show which records could not be deleted and why.
+
+---
+
+### "List all bulk delete jobs" / "Show recent bulk deletes"
+
+Call `list_bulk_delete_jobs`. Optional `status` filter: `waiting`, `running`, `completed`, `failed`, `cancelled`.
+
+Present results as a table: Job Name | Status | Created | Completed | JobId.
+
+---
+
+### "Cancel the bulk delete job"
+
+1. Call `get_bulk_delete_job` to confirm the job is still active (statecode 0, 1, or 2).
+2. Warn the user that cancellation stops the job — already-deleted records are NOT restored.
+3. Call `cancel_bulk_delete_job` with the `job_id`.
+
+---
+
+### "Why did some records fail to delete?"
+
+Call `get_bulk_delete_failures` with the `job_id`. The response includes:
+- `objectid` — the GUID of the record that failed
+- `errordescription` — the reason for failure (e.g. cascading relationships, active child records)
+
+Common failure reasons:
+- **Relationship constraints** — child records still exist and the relationship is set to Restrict
+- **Locked records** — record in use by another process
+- **Security** — the service principal lacks delete privilege on the record
+
+---
+
+## Tips
+
+- **Irreversible** — bulk delete permanently removes records. Always confirm with the user before creating a job.
+- **Recurrence** — set `recurrence_pattern` to run the job on a schedule (e.g. daily cleanup). Leave empty for a one-time run.
+- **Large datasets** — jobs run asynchronously; large tables may take minutes to hours. Poll with `get_bulk_delete_job`.
+- **Failures are normal** — a job can succeed overall even if some records failed. Check `get_bulk_delete_failures` after completion.


### PR DESCRIPTION
## Summary

- Adds 5 new MCP tools for creating and managing Dynamics 365 bulk deletion jobs via the `BulkDelete` action and `asyncoperations` / `bulkdeletefailures` entities
- Adds a `bulk-delete` skill that guides through the full create → monitor → inspect-failures workflow

## New Tools

| Tool | Description |
|------|-------------|
| `create_bulk_delete_job` | Triggers the `BulkDelete` action with a `QueryExpression`; supports optional per-attribute filter conditions so you can target a subset of records |
| `list_bulk_delete_jobs` | Lists bulk delete async operations; filterable by status (`waiting`, `running`, `completed`, `failed`, `cancelled`) |
| `get_bulk_delete_job` | Fetches status, start time, and completion details for a specific job by `asyncoperationid` |
| `cancel_bulk_delete_job` | Stops a waiting or running job by deleting its `asyncoperation` record |
| `get_bulk_delete_failures` | Returns `bulkdeletefailure` records for a job — shows which records failed and why |

## New Skill

`skills/bulk-delete/SKILL.md` — covers:
- Resolving entity logical name and building filter conditions
- Confirming scope with user before irreversible deletion
- Status code reference table (statecode / statuscode combinations)
- Failure diagnosis (relationship constraints, locked records, security)

## Test plan

- [x] TypeScript compiles cleanly (`npm run build`)
- [ ] `create_bulk_delete_job` with no filter deletes all records of target entity
- [ ] `create_bulk_delete_job` with `filter_conditions` deletes only matching records
- [ ] `list_bulk_delete_jobs` returns jobs; status filter narrows results correctly
- [ ] `get_bulk_delete_job` returns correct statecode/statuscode after creation
- [ ] `cancel_bulk_delete_job` stops a running job
- [ ] `get_bulk_delete_failures` returns failure records for a partially-failed job

🤖 Generated with [Claude Code](https://claude.com/claude-code)